### PR TITLE
Fix dead Tae Kim Grammar Guide link

### DIFF
--- a/src/components/ExplanationCard.tsx
+++ b/src/components/ExplanationCard.tsx
@@ -41,7 +41,7 @@ function ExplanationCard() {
       </Text>
       <Text italic mt="sm">
         See the relevant sections on{" "}
-        <Anchor href="https://itazuraneko.neocities.org/grammar/taekim#0%20The%20Writing%20System">
+        <Anchor href="https://gohoneko.neocities.org/grammar/taekim#0%20The%20Writing%20System">
           Tae Kim&apos;s Guide
         </Anchor>{" "}
         for more information.


### PR DESCRIPTION
Replaced the dead Tae Kim Grammar Link with new mirror:
https://gohoneko.neocities.org/grammar/taekim#0%20The%20Writing%20System 