### PR TITLE
feat: Save progress during brute force learning

### DIFF
--- a/src/components/BruteForceMenu.tsx
+++ b/src/components/BruteForceMenu.tsx
@@ -1,7 +1,15 @@
-import { Button, ButtonProps, Container, Group, List, Text, Title } from "@mantine/core";
+import { ActionIcon, Button, ButtonProps, Container, Group, List, Text, Title, Tooltip } from "@mantine/core";
+import { IconTrash } from "@tabler/icons-react";
 import React, { useState } from "react";
+import { bruteForce, BruteForceProgress } from "../utilities/bruteforce";
 import { KanaNames } from "../utilities/kana";
+import { tooltipProps } from "../utilities/tooltip";
 import BruteForcePractice from "./BruteForcePractice";
+
+function formatProgress(progress: BruteForceProgress): string {
+  const phase = progress.learning ? "Learning" : "Reviewing";
+  return `${phase} ${progress.stageName}`;
+}
 
 function BruteForceMenu() {
   const buttonProps: ButtonProps = {
@@ -14,8 +22,21 @@ function BruteForceMenu() {
   };
 
   const [kanaType, setKanaType] = useState<KanaNames | null>(null);
+  const [savedProgress, setSavedProgress] = useState<{
+    hiragana: BruteForceProgress | null;
+    katakana: BruteForceProgress | null;
+  }>({
+    hiragana: bruteForce.loadProgress("hiragana"),
+    katakana: bruteForce.loadProgress("katakana"),
+  });
 
-  if (kanaType) return <BruteForcePractice kanaType={kanaType} />;
+  if (kanaType) return <BruteForcePractice kanaType={kanaType} initialProgress={savedProgress[kanaType]} />;
+
+  const handleClearProgress = (type: KanaNames, e: React.MouseEvent) => {
+    e.stopPropagation();
+    bruteForce.clearProgress(type);
+    setSavedProgress((prev) => ({ ...prev, [type]: null }));
+  };
 
   return (
     <Container px={0}>
@@ -51,10 +72,34 @@ function BruteForceMenu() {
         <Button {...buttonProps} onClick={() => setKanaType("hiragana")}>
           <Title order={3}>Hiragana</Title>
           <Text weight="normal">ひらがな</Text>
+          {savedProgress.hiragana && (
+            <Group spacing={4} mt={4} position="center" noWrap>
+              <Text weight="normal" fz="xs" c="dimmed">
+                Resume: {formatProgress(savedProgress.hiragana)}
+              </Text>
+              <Tooltip {...tooltipProps} label="Clear saved progress">
+                <ActionIcon size="xs" variant="subtle" onClick={(e) => handleClearProgress("hiragana", e)}>
+                  <IconTrash size={12} />
+                </ActionIcon>
+              </Tooltip>
+            </Group>
+          )}
         </Button>
         <Button {...buttonProps} onClick={() => setKanaType("katakana")}>
           <Title order={3}>Katakana</Title>
           <Text weight="normal">カタカナ</Text>
+          {savedProgress.katakana && (
+            <Group spacing={4} mt={4} position="center" noWrap>
+              <Text weight="normal" fz="xs" c="dimmed">
+                Resume: {formatProgress(savedProgress.katakana)}
+              </Text>
+              <Tooltip {...tooltipProps} label="Clear saved progress">
+                <ActionIcon size="xs" variant="subtle" onClick={(e) => handleClearProgress("katakana", e)}>
+                  <IconTrash size={12} />
+                </ActionIcon>
+              </Tooltip>
+            </Group>
+          )}
         </Button>
       </Group>
     </Container>

--- a/src/components/BruteForcePractice.tsx
+++ b/src/components/BruteForcePractice.tsx
@@ -63,12 +63,18 @@ interface BruteForcePracticeStats {
 
 export interface BruteForcePracticeProps {
   kanaType: KanaNames;
+  initialProgress?: { stageName: string; learning: boolean } | null;
 }
 
-function BruteForcePractice({ kanaType }: BruteForcePracticeProps) {
+function BruteForcePractice({ kanaType, initialProgress }: BruteForcePracticeProps) {
   const [openedOptions, { toggle: toggleOptions }] = useDisclosure(true);
 
-  const [stage, setStage] = useState({ stage: bruteForce.stages[0], learning: true });
+  const resolvedInitialStage = initialProgress ? bruteForce.getStageByName(initialProgress.stageName) : undefined;
+
+  const [stage, setStage] = useState({
+    stage: resolvedInitialStage ?? bruteForce.stages[0],
+    learning: initialProgress && resolvedInitialStage ? initialProgress.learning : true,
+  });
   const [stageSatisfied, setStageSatisfied] = useState(false);
   const nextStage = bruteForce.getNextStage(stage.stage);
   const kanaOfStage = bruteForce.buildKanaOfStage(kanaType, stage.stage, stage.learning);
@@ -76,10 +82,26 @@ function BruteForcePractice({ kanaType }: BruteForcePracticeProps) {
   const [stats, setStats] = useState<BruteForcePracticeStats>({
     correctCount: 0,
     totalCount: 0,
-    remainingLimits: buildRemainingKanaLimits(kanaOfStage, statThresholds.learning.perKanaLimit),
+    remainingLimits: buildRemainingKanaLimits(
+      kanaOfStage,
+      statThresholds[stage.learning ? "learning" : "reviewing"].perKanaLimit,
+    ),
     rollingWindow: [],
     rollingWindowInEffect: false,
   });
+
+  const saveProgress = (s: typeof stage) => {
+    bruteForce.saveProgress(kanaType, {
+      stageName: s.stage.name,
+      learning: s.learning,
+    });
+  };
+
+  const hasInitiallySaved = useRef(false);
+  if (!hasInitiallySaved.current) {
+    hasInitiallySaved.current = true;
+    saveProgress(stage);
+  }
   const effectiveStatThresholds = statThresholds[stage.learning ? "learning" : "reviewing"];
   const statCounts = {
     ...countStatGoals(stats),
@@ -130,6 +152,9 @@ function BruteForcePractice({ kanaType }: BruteForcePracticeProps) {
       counts.rollingCorrectCount >= effectiveStatThresholds.rollingWindowCorrectLimit
     ) {
       setStageSatisfied(true);
+      if (bruteForce.isFinalStage(stage.stage) && !stage.learning) {
+        bruteForce.clearProgress(kanaType);
+      }
     }
 
     if (stage.learning && firstEncounter) {
@@ -166,16 +191,19 @@ function BruteForcePractice({ kanaType }: BruteForcePracticeProps) {
 
     setFirstEncounterKana(newStage.learning ? newKanaOfStage.map((k) => k.kana) : []);
 
-    setStats((prev) => ({
-      correctCount: prev.correctCount,
-      totalCount: prev.totalCount,
-      remainingLimits: buildRemainingKanaLimits(
-        newKanaOfStage,
-        statThresholds[newStage.learning ? "learning" : "reviewing"].perKanaLimit,
-      ),
-      rollingWindow: [],
-      rollingWindowInEffect: false,
-    }));
+    setStats((prev) => {
+      saveProgress(newStage);
+      return {
+        correctCount: prev.correctCount,
+        totalCount: prev.totalCount,
+        remainingLimits: buildRemainingKanaLimits(
+          newKanaOfStage,
+          statThresholds[newStage.learning ? "learning" : "reviewing"].perKanaLimit,
+        ),
+        rollingWindow: [],
+        rollingWindowInEffect: false,
+      };
+    });
   };
 
   const handleMiscOptionsChange = (newOptions: typeof miscOptions) => {

--- a/src/components/BruteForcePractice.tsx
+++ b/src/components/BruteForcePractice.tsx
@@ -114,7 +114,9 @@ function BruteForcePractice({ kanaType, initialProgress }: BruteForcePracticePro
 
   const [currentKana, setCurrentKana] = useState(streamRef.current.current());
 
-  const [firstEncounterKana, setFirstEncounterKana] = useState<KanaChars[]>(kanaOfStage.map((k) => k.kana));
+  const [firstEncounterKana, setFirstEncounterKana] = useState<KanaChars[]>(
+    stage.learning ? kanaOfStage.map((k) => k.kana) : [],
+  );
   const firstEncounter = firstEncounterKana.includes(currentKana.kana);
 
   const computeNewStats = (correct: boolean): BruteForcePracticeStats => {

--- a/src/components/BruteForcePracticeOptions.tsx
+++ b/src/components/BruteForcePracticeOptions.tsx
@@ -1,4 +1,5 @@
-import { Checkbox, Container, Title } from "@mantine/core";
+import { Button, Checkbox, Container, Title } from "@mantine/core";
+import { IconTrash } from "@tabler/icons-react";
 import React from "react";
 import { bruteForce, BruteForcePracticeStage } from "../utilities/bruteforce";
 import { KanaNames } from "../utilities/kana";
@@ -36,6 +37,16 @@ function BruteForcePracticeOptions({
             });
           }}
         />
+        <Button
+          variant="subtle"
+          compact
+          color="red"
+          mt="sm"
+          leftIcon={<IconTrash size={14} />}
+          onClick={() => bruteForce.clearProgress(kanaType)}
+        >
+          Clear saved progress
+        </Button>
       </Container>
 
       <Title order={6} mb="sm">

--- a/src/utilities/bruteforce.ts
+++ b/src/utilities/bruteforce.ts
@@ -130,12 +130,56 @@ const getKanaConfigurationForStage = (
   return config;
 };
 
+const getStageByName = (name: string): BruteForcePracticeStage | undefined =>
+  bruteForcePracticeStages.find((s) => s.name === name);
+
+export interface BruteForceProgress {
+  stageName: string;
+  learning: boolean;
+}
+
+const progressStorageKey = (kanaType: KanaNames) => `bruteforce-progress-${kanaType}`;
+
+const saveProgress = (kanaType: KanaNames, progress: BruteForceProgress): void => {
+  try {
+    localStorage.setItem(progressStorageKey(kanaType), JSON.stringify(progress));
+  } catch {
+    // Silently ignore storage errors (e.g. quota exceeded, private browsing)
+  }
+};
+
+const loadProgress = (kanaType: KanaNames): BruteForceProgress | null => {
+  try {
+    const raw = localStorage.getItem(progressStorageKey(kanaType));
+    if (!raw) return null;
+    const parsed = JSON.parse(raw);
+    if (typeof parsed.stageName === "string" && typeof parsed.learning === "boolean") {
+      return parsed as BruteForceProgress;
+    }
+    return null;
+  } catch {
+    return null;
+  }
+};
+
+const clearProgress = (kanaType: KanaNames): void => {
+  try {
+    localStorage.removeItem(progressStorageKey(kanaType));
+  } catch {
+    // Silently ignore
+  }
+};
+
 export const bruteForce = {
   stages: bruteForcePracticeStages,
   getNextStage,
   isFinalStage,
+  getStageByName,
   getKanaOfStage,
   getAllKanaForStage,
   buildKanaOfStage,
   getKanaConfigurationForStage,
+  saveProgress,
+  loadProgress,
+  clearProgress,
 };


### PR DESCRIPTION
This adds the ability to save and clear your progress during brute force learning. 

<img width="1962" height="429" alt="image" src="https://github.com/user-attachments/assets/25785716-2967-4fc3-b73f-8a0082391f60" />

closes issue #14 
