### PR TITLE
feat: accept kana answers in every practice mode

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,6 +6,9 @@ import PracticeKanaInput from "./components/PracticeKanaInput";
 import ExplanationCard from "./components/ExplanationCard";
 
 document.onkeydown = (event) => {
+  // Refocusing mid-composition risks discarding what the IME is holding
+  if (event.isComposing) return;
+
   if (event.key.length > 1 && ["Backspace", "Enter"].every((allowedKey) => event.code !== allowedKey)) return;
 
   // Not ideal

--- a/src/components/NumberPractice.tsx
+++ b/src/components/NumberPractice.tsx
@@ -3,7 +3,7 @@ import { useDisclosure } from "@mantine/hooks";
 import React, { useRef, useState } from "react";
 import { shuffledStream, stringifyRomaji } from "../utilities/kana";
 import { tooltipProps } from "../utilities/tooltip";
-import { basicDigits, getBasicDigitQuestion, generateCompoundQuestion } from "../utilities/numbers";
+import { basicDigits, getBasicDigitQuestion, generateCompoundQuestion, NumberQuestion } from "../utilities/numbers";
 import KanaAnswerTooltipHint from "./KanaAnswerTooltipHint";
 import PracticeKanaInput from "./PracticeKanaInput";
 import PracticeOptions from "./PracticeOptions";
@@ -18,8 +18,8 @@ export interface NumberPracticeConfiguration {
 }
 
 interface QuestionStream {
-  current: () => { kana: string; romaji: string | string[] };
-  next: () => { kana: string; romaji: string | string[] };
+  current: () => NumberQuestion;
+  next: () => NumberQuestion;
 }
 
 const buildBasicStream = (mode: NumberPracticeConfiguration["basicMode"]): QuestionStream => {

--- a/src/components/PracticeKanaInput.tsx
+++ b/src/components/PracticeKanaInput.tsx
@@ -1,18 +1,32 @@
 import { Container, Group, Stack, Text, TextInput, Tooltip } from "@mantine/core";
-import React, { ChangeEventHandler, KeyboardEventHandler, useState } from "react";
-import { kanaMap, stringifyRomaji } from "../utilities/kana";
+import React, { ChangeEventHandler, CompositionEventHandler, KeyboardEventHandler, useRef, useState } from "react";
+import { kanaMap, stringifyRomaji, swapKanaScript } from "../utilities/kana";
 import { tooltipProps } from "../utilities/tooltip";
 
 const kanaInputId = "kana-input";
 
+const toAnswers = (answer: string | string[]): string[] => (Array.isArray(answer) ? answer : [answer]);
+
+// "n" is a prefix of every n-row romaji, so on its own it is a partial answer rather than a wrong one
 const romajiSet = new Set(
   Object.values(kanaMap)
     .flat()
     .filter((val) => val !== "n"),
 );
 
+// Same idea for kana: き is a step towards きゃ, so only kana that no other kana begins with can be wrong
+const kanaChars = Object.keys(kanaMap);
+const kanaSet = new Set(
+  kanaChars.filter((char) => !kanaChars.some((other) => other !== char && other.startsWith(char))),
+);
+
 export interface PracticeKanaInputProps {
-  kana: { kana: string; romaji: string | string[] };
+  /**
+   * `reading` is the answer written in kana, accepted alongside `romaji`. It defaults to the
+   * displayed `kana`, which is already the reading in every mode but `number` — there the
+   * question is kanji or digits, so the reading has to be supplied.
+   */
+  kana: { kana: string; romaji: string | string[]; reading?: string | string[] };
   showAnswer?: boolean;
   onAnswer: (correct: boolean) => void;
   showCorrectAnswer: boolean;
@@ -23,7 +37,7 @@ export interface PracticeKanaInputProps {
 }
 
 function PracticeKanaInput({
-  kana: { kana, romaji },
+  kana: { kana, romaji, reading },
   showAnswer,
   onAnswer,
   showCorrectAnswer,
@@ -34,51 +48,87 @@ function PracticeKanaInput({
 }: PracticeKanaInputProps) {
   const stringifiedRomaji = stringifyRomaji(romaji);
 
+  const romajiAnswers = toAnswers(romaji);
+  // Either script is accepted regardless of which one the question is written in, so that
+  // whoever is typing kana can practise the script they came to practise
+  const kanaAnswers = (reading !== undefined ? toAnswers(reading) : mode === "number" ? [] : [kana]).flatMap(
+    (answer) => [answer, swapKanaScript(answer)],
+  );
+
+  // A kana answer is shorter than its romaji, but an IME still needs room for the romaji being
+  // composed into it — and then some, for input such as "texi" becoming ティ
+  const maxAnswerLength = Math.max(
+    5,
+    ...romajiAnswers.map((answer) => answer.length),
+    ...kanaAnswers.map((answer) => answer.length * 3),
+  );
+
   const [kanaInputValue, setKanaInputValue] = useState("");
   const [gaveIncorrectAnswer, setGaveIncorrectAnswer] = useState(false);
+
+  const composingRef = useRef(false);
+  // Emptying the field mid-composition leaves some IMEs to re-insert their buffer once the
+  // composition ends; remember what was accepted so that echo can be dropped rather than
+  // spilling into the next question
+  const consumedRef = useRef<string | null>(null);
 
   const resetState = () => {
     setKanaInputValue("");
     setGaveIncorrectAnswer(false);
   };
 
-  const checkKanaInput: ChangeEventHandler<HTMLInputElement> = (event) => {
-    const value = event.currentTarget.value.toLowerCase();
+  const checkInput = (rawValue: string) => {
+    // Composed dakuten arrive decomposed from some IMEs, so が never matches が without this
+    const value = rawValue.toLowerCase().normalize("NFC");
 
-    if (value === romaji || (Array.isArray(romaji) && romaji.some((romaji) => romaji === value))) {
-      resetState();
-      onAnswer(!gaveIncorrectAnswer);
-    } else {
-      if (romajiSet.has(value)) {
-        setGaveIncorrectAnswer(true);
+    if (value === "") {
+      setKanaInputValue("");
+      return;
+    }
+
+    if (consumedRef.current !== null) {
+      const consumed = consumedRef.current;
+      consumedRef.current = null;
+      if (value === consumed) {
+        setKanaInputValue("");
+        return;
       }
-      setKanaInputValue(value);
     }
-  };
 
-  const checkWordInput: ChangeEventHandler<HTMLInputElement> = (event) => {
-    const value = event.currentTarget.value.toLowerCase();
-
-    if (value === romaji) {
-      resetState();
-      onAnswer(true);
-    } else {
-      setKanaInputValue(value);
-    }
-  };
-
-  const checkNumberInput: ChangeEventHandler<HTMLInputElement> = (event) => {
-    const value = event.currentTarget.value.toLowerCase();
-
-    if (value === romaji || (Array.isArray(romaji) && romaji.some((r) => r === value))) {
+    if (romajiAnswers.includes(value) || kanaAnswers.includes(value)) {
+      if (composingRef.current) consumedRef.current = value;
       resetState();
       onAnswer(!gaveIncorrectAnswer);
-    } else {
-      setKanaInputValue(value);
+      return;
     }
+
+    if (mode === "kana" && (romajiSet.has(value) || kanaSet.has(value))) {
+      setGaveIncorrectAnswer(true);
+    }
+    setKanaInputValue(value);
+  };
+
+  const handleChange: ChangeEventHandler<HTMLInputElement> = (event) => {
+    // compositionend does not always arrive, so it cannot be the only thing that ends a
+    // composition; an input event that is not itself composing proves there is none in flight
+    if (!(event.nativeEvent as InputEvent).isComposing) composingRef.current = false;
+
+    checkInput(event.currentTarget.value);
+  };
+
+  const handleCompositionStart = () => {
+    composingRef.current = true;
+  };
+
+  const handleCompositionEnd: CompositionEventHandler<HTMLInputElement> = (event) => {
+    composingRef.current = false;
+    checkInput(event.currentTarget.value);
   };
 
   const skip: KeyboardEventHandler<HTMLInputElement> = (event) => {
+    // Enter is also how an IME commits its composition, which must not skip the question
+    if (event.nativeEvent.isComposing || composingRef.current) return;
+
     if (event.key === "Enter") {
       resetState();
       onAnswer(false);
@@ -104,11 +154,13 @@ function PracticeKanaInput({
               textAlign: "center",
             },
           })}
-          maxLength={Math.max(5, ...(Array.isArray(romaji) ? romaji.map((r) => r.length) : [romaji.length]))}
+          maxLength={maxAnswerLength}
           placeholder={placeholder}
           value={kanaInputValue}
           error={gaveIncorrectAnswer ? (showCorrectAnswer ? `${kana} = ${stringifiedRomaji}` : true) : false}
-          onChange={mode === "word" ? checkWordInput : mode === "number" ? checkNumberInput : checkKanaInput}
+          onChange={handleChange}
+          onCompositionStart={handleCompositionStart}
+          onCompositionEnd={handleCompositionEnd}
           onKeyDown={skip}
         />
       </Group>

--- a/src/utilities/kana.ts
+++ b/src/utilities/kana.ts
@@ -92,6 +92,24 @@ export function getDefaultRomaji(romaji: KanaRomaji): string {
   return Array.isArray(romaji) ? romaji[0] : romaji;
 }
 
+const hiraganaStart = "ぁ".charCodeAt(0);
+const hiraganaEnd = "ゖ".charCodeAt(0);
+const katakanaOffset = "ァ".charCodeAt(0) - hiraganaStart;
+
+/**
+ * Rewrites every kana in the given text in the other script, leaving anything without a
+ * counterpart untouched — kanji, digits, and marks shared by both scripts such as ー.
+ */
+export function swapKanaScript(text: string): string {
+  return Array.from(text, (char) => {
+    const code = char.charCodeAt(0);
+    if (code >= hiraganaStart && code <= hiraganaEnd) return String.fromCharCode(code + katakanaOffset);
+    if (code >= hiraganaStart + katakanaOffset && code <= hiraganaEnd + katakanaOffset)
+      return String.fromCharCode(code - katakanaOffset);
+    return char;
+  }).join("");
+}
+
 export function stringifyRomaji(romaji: KanaRomaji): string {
   return Array.isArray(romaji) ? romaji.join(" / ") : romaji;
 }

--- a/src/utilities/numbers.ts
+++ b/src/utilities/numbers.ts
@@ -2,27 +2,41 @@ export interface BasicDigit {
   kanji: string;
   digit: number;
   romaji: string | string[];
+  reading: string | string[];
+}
+
+/** A question, along with every form its answer may be given in */
+export interface NumberQuestion {
+  kana: string;
+  romaji: string | string[];
+  reading: string | string[];
 }
 
 export const basicDigits: readonly BasicDigit[] = Object.freeze([
-  { kanji: "零", digit: 0, romaji: "zero" },
-  { kanji: "〇", digit: 0, romaji: "zero" },
-  { kanji: "一", digit: 1, romaji: "ichi" },
-  { kanji: "二", digit: 2, romaji: "ni" },
-  { kanji: "三", digit: 3, romaji: "san" },
-  { kanji: "四", digit: 4, romaji: ["yon", "shi"] },
-  { kanji: "五", digit: 5, romaji: "go" },
-  { kanji: "六", digit: 6, romaji: "roku" },
-  { kanji: "七", digit: 7, romaji: ["nana", "shichi"] },
-  { kanji: "八", digit: 8, romaji: "hachi" },
-  { kanji: "九", digit: 9, romaji: ["kyuu", "ku"] },
-  { kanji: "十", digit: 10, romaji: "juu" },
-  { kanji: "百", digit: 100, romaji: "hyaku" },
-  { kanji: "千", digit: 1000, romaji: "sen" },
-  { kanji: "万", digit: 10000, romaji: "man" },
+  { kanji: "零", digit: 0, romaji: "zero", reading: ["れい", "ゼロ"] },
+  { kanji: "〇", digit: 0, romaji: "zero", reading: ["れい", "ゼロ"] },
+  { kanji: "一", digit: 1, romaji: "ichi", reading: "いち" },
+  { kanji: "二", digit: 2, romaji: "ni", reading: "に" },
+  { kanji: "三", digit: 3, romaji: "san", reading: "さん" },
+  { kanji: "四", digit: 4, romaji: ["yon", "shi"], reading: ["よん", "し"] },
+  { kanji: "五", digit: 5, romaji: "go", reading: "ご" },
+  { kanji: "六", digit: 6, romaji: "roku", reading: "ろく" },
+  { kanji: "七", digit: 7, romaji: ["nana", "shichi"], reading: ["なな", "しち"] },
+  { kanji: "八", digit: 8, romaji: "hachi", reading: "はち" },
+  { kanji: "九", digit: 9, romaji: ["kyuu", "ku"], reading: ["きゅう", "く"] },
+  { kanji: "十", digit: 10, romaji: "juu", reading: "じゅう" },
+  { kanji: "百", digit: 100, romaji: "hyaku", reading: "ひゃく" },
+  { kanji: "千", digit: 1000, romaji: "sen", reading: "せん" },
+  { kanji: "万", digit: 10000, romaji: "man", reading: "まん" },
 ]);
 
 const digitKanji = ["零", "一", "二", "三", "四", "五", "六", "七", "八", "九"];
+
+const digitKana = ["", "いち", "に", "さん", "よん", "ご", "ろく", "なな", "はち", "きゅう"];
+
+// Counts whose reading is not simply the digit followed by the unit
+const senKana: { [key: number]: string } = { 1: "せん", 3: "さんぜん", 8: "はっせん" };
+const hyakuKana: { [key: number]: string } = { 1: "ひゃく", 3: "さんびゃく", 6: "ろっぴゃく", 8: "はっぴゃく" };
 
 export function numberToKanji(n: number): string {
   if (n < 0 || n > 99999 || !Number.isInteger(n)) throw Error(`Invalid number: ${n}`);
@@ -44,17 +58,38 @@ export function numberToKanji(n: number): string {
   return result;
 }
 
-export function generateCompoundQuestion(maxRange: number): { kana: string; romaji: string } {
-  const n = 1 + Math.floor(Math.random() * maxRange);
-  return { kana: numberToKanji(n), romaji: String(n) };
+/**
+ * Only the everyday reading is produced: 四 is よん rather than し, 七 is なな rather than しち,
+ * and 九 is きゅう rather than く, matching the canonical form {@link numberToKanji} builds.
+ */
+export function numberToKana(n: number): string {
+  if (n < 0 || n > 99999 || !Number.isInteger(n)) throw Error(`Invalid number: ${n}`);
+  if (n === 0) return "れい";
+
+  let result = "";
+  const man = Math.floor(n / 10000);
+  const sen = Math.floor((n % 10000) / 1000);
+  const hyaku = Math.floor((n % 1000) / 100);
+  const juu = Math.floor((n % 100) / 10);
+  const ichi = n % 10;
+
+  if (man > 0) result += digitKana[man] + "まん";
+  if (sen > 0) result += senKana[sen] ?? digitKana[sen] + "せん";
+  if (hyaku > 0) result += hyakuKana[hyaku] ?? digitKana[hyaku] + "ひゃく";
+  if (juu > 0) result += (juu === 1 ? "" : digitKana[juu]) + "じゅう";
+  if (ichi > 0) result += digitKana[ichi];
+
+  return result;
 }
 
-export function getBasicDigitQuestion(
-  digit: BasicDigit,
-  mode: "kanji_to_romaji" | "digits_to_romaji",
-): { kana: string; romaji: string | string[] } {
+export function generateCompoundQuestion(maxRange: number): NumberQuestion {
+  const n = 1 + Math.floor(Math.random() * maxRange);
+  return { kana: numberToKanji(n), romaji: String(n), reading: numberToKana(n) };
+}
+
+export function getBasicDigitQuestion(digit: BasicDigit, mode: "kanji_to_romaji" | "digits_to_romaji"): NumberQuestion {
   if (mode === "kanji_to_romaji") {
-    return { kana: digit.kanji, romaji: digit.romaji };
+    return { kana: digit.kanji, romaji: digit.romaji, reading: digit.reading };
   }
-  return { kana: String(digit.digit), romaji: digit.romaji };
+  return { kana: String(digit.digit), romaji: digit.romaji, reading: digit.reading };
 }


### PR DESCRIPTION
Closes #18.

Answers may now be given in kana as well as romaji, in every mode, so a Japanese keyboard can be used throughout instead of switching to romaji to answer.

Nothing about this is surfaced in the UI — it is only there for whoever goes looking for it.

## Nothing changes for anyone answering in romaji

No romaji answer is also a valid kana string, so accepting both cannot alter how an existing answer is judged. That is checked across the whole map rather than assumed: every romaji value in `kanaMap` was compared against every kana key, and the overlap is empty.

There are no visual changes at all — widths, placeholders, fonts and layout are untouched.

The one literal difference is `maxLength`, which now has to fit a kana answer as well: in Free mode for combination kana it goes from 5 to 6, and in Word mode for こんにちは from 10 to 15. It is only reachable by deliberately typing past the old cap, where the answer is wrong either way, and no answer is graded differently. Making the cap adapt to the field's contents would erase even this, but a desktop IME holds romaji in the field before any kana appears, so a romaji-sized cap would block the feature outright.

## What counts as a kana answer

Free, Brute Force and Word practice already display the reading, so the displayed kana is the accepted kana answer.

Number practice displays kanji or digits instead, so it supplies its own reading. For compound numbers that means a `numberToKana` alongside `numberToKanji`, covering the euphonic changes — 300 さんびゃく, 600 ろっぴゃく, 800 はっぴゃく, 3000 さんぜん, 8000 はっせん. It builds the everyday reading only (四 as よん rather than し), matching the single canonical form `numberToKanji` already produces. The question itself is never accepted as its own answer.

Either script is accepted whichever one the question is written in, so a katakana question can be answered in hiragana and vice versa. The conversion leaves marks shared by both scripts alone, so コーヒー becomes こーひー rather than losing its long vowel mark.

A kana answer is judged wrong on the same terms as romaji, with one exception: a kana that another kana begins with (き on the way to きゃ) is a partial answer rather than a wrong one. That mirrors the existing exemption for `n`, and is derived from the map rather than hardcoded, so it stays correct if kana are added.

## IME handling

Typing kana means typing through an IME, which the input had no handling for. Each of these was observed in Chromium driven through CDP with real composition events, not reasoned about in the abstract:

- **Enter commits a composition**, and would have skipped the question and scored it wrong. It is now ignored while composing.
- **Answering mid-composition empties the field**, after which the IME re-inserts its buffer. That echo is now dropped instead of spilling into the next question.
- **`compositionend` is not guaranteed to arrive.** An input event that is not itself composing therefore also ends a composition — otherwise a single kana answer would leave Enter unable to skip for the rest of the session.
- **`maxLength` came from the romaji answer**, which truncated a compound reading at five characters.
- Input is normalised to NFC so decomposed dakuten still match.

## Verification

`numberToKana` was checked across all 100,000 values in range: every output is kana only, and the tricky readings were asserted individually. Script swapping round-trips over every word, kana and number reading in the app, and no katakana word converts into a different hiragana word.

Driven in a browser across all four modes, 28 checks: romaji still accepted, kana accepted both typed directly and through an IME composition, katakana accepted for hiragana questions and the reverse, Enter still skipping normally and after an IME answer, combination bases not flagged as wrong, digits still accepted in compound mode, and the input left empty after every commit.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EWPU9XzNA9eVqbH37WWGsT)_